### PR TITLE
カレンダー表示時の写真表示まで

### DIFF
--- a/app/controllers/daily_photos_controller.rb
+++ b/app/controllers/daily_photos_controller.rb
@@ -1,0 +1,31 @@
+class DailyPhotosController < ApplicationController
+  include UserAgent
+  include DecryptedId
+
+  before_action :set_request_variant
+  before_action :set_album, only: %i( index )
+  before_action :set_date_from_created_at_ymd, only: %i( index )
+  before_action :set_photos, only: %i( index )
+
+  def index 
+  end
+
+  private
+
+  def set_request_variant
+    request.variant = :tablet if tablet?
+    request.variant = :phone if mobile?
+  end
+
+  def set_album
+    @album = @current_group.albums.where(id: decrypted_id(params[:album_id])).first
+  end
+
+  def set_date_from_created_at_ymd
+    @selected_date = Date.strptime(params[:created_at_ymd], '%Y/%m/%d')
+  end
+
+  def set_photos
+    @photos = @album.photos.where(created_at: @selected_date...@selected_date.next_day).page(params[:page])
+  end
+end

--- a/app/views/daily_photos/index.html.slim
+++ b/app/views/daily_photos/index.html.slim
@@ -1,0 +1,7 @@
+h1
+  | #{@album.title}の#{@photos.first.created_at_ymd} の写真
+
+li
+  = link_to '戻る', album_photos_path(@album)
+   
+  = render 'photos/list'

--- a/app/views/photos/_calender.html.slim
+++ b/app/views/photos/_calender.html.slim
@@ -3,6 +3,6 @@
 
   br/
   - if photos.first
-    = image_tag photos.first.thumb_url
+    = link_to image_tag(photos.first.thumb_url), album_daily_photos_path(album_id: @album.encrypted_id, created_at_ymd: photos.first.created_at_ymd) 
   - else
     = image_tag 'np_photo.gif'

--- a/app/views/photos/_list.html.slim
+++ b/app/views/photos/_list.html.slim
@@ -15,4 +15,4 @@
         = link_to '拡大', "#photo_view_#{photo.id}", data: { toggle: "modal", target: ".photo_view_#{photo.id}", backdrop: false }
         | &nbsp;&nbsp; | &nbsp;&nbsp; #{ link_to '削除', album_photo_path(album_id: @album.encrypted_id, id: photo.encrypted_id), method: :delete,  data: { confirm: '削除しますか？'} }
 
-      = render 'show', photo: photo
+      = render 'photos/show', photo: photo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   resources :albums, only: %i( index show new create edit update destroy ) do
     ## 写真関連
     resources :photos, only: %i( index show destroy )
+    resources :daily_photos, only: %i( index )
   end
   resource :photos, only: %i( new create )
   resource  :photo_search, only: %i( create )


### PR DESCRIPTION
# 概要

カレンダー表示で写真の詳細を表示機能の追加
# やったこと
- カレンダー表示にあの画像をクリック可能にした
- クリックした後の詳細画面を追加
# 課題
- 詳細画面の戻るリンクをクリッウした後のカレンダー表示が初期化状態である
